### PR TITLE
fix JsonDeserializer: parsing of text in root node

### DIFF
--- a/McMotdParser.Test/Deserializer/JsonDeserializerTests.cs
+++ b/McMotdParser.Test/Deserializer/JsonDeserializerTests.cs
@@ -25,6 +25,22 @@ namespace McMotdParser.Test.Deserializer
 
             Assert.True(testResult.SequenceEqual(expect));
         }
+        
+        [Fact]
+        public void NestedJsonMotdDeserialize()
+        {
+            string raw_motd = @"{""color"":""red"",""extra"":[{""color"":""green"",""text"":""World""}],""text"":""Hello ""}";
+            var testResult = new MotdParser().deserialize(raw_motd);
+            
+            List<MotdContent> expect = new List<MotdContent>()
+            {
+                new MotdContent{ Color = "#FF5555", Text = "Hello "},
+                new MotdContent{ Color = "#55FF55", Text = "World"},
+            };
+
+            Assert.True(testResult.SequenceEqual(expect));
+        }
+        
         [Fact]
         public void ComplexJsonMotdDeserialize()
         {
@@ -35,6 +51,7 @@ namespace McMotdParser.Test.Deserializer
             
             List<MotdContent> expect = new List<MotdContent>()
             {
+                new MotdContent{ Color = "#808080", Text = " "},
                 new MotdContent{ Color = "#55FFFF", Text = "◆ "},
                 new MotdContent{ Color = "#00ffff", Text = "스", TextFormatting = new HashSet<TextFormatEnum> { TextFormatEnum.Bold,TextFormatEnum.Italic } },
                 new MotdContent{ Color = "#19e5ff", Text = "티", TextFormatting = new HashSet<TextFormatEnum> { TextFormatEnum.Bold,TextFormatEnum.Italic } },

--- a/McMotdParser/Deserializer/MotdDeserializer.cs
+++ b/McMotdParser/Deserializer/MotdDeserializer.cs
@@ -29,29 +29,15 @@ namespace McMotdParser.Deserializer
             using (JsonDocument doc = JsonDocument.ParseValue(ref reader))
             {
                 var root = doc.RootElement;
+                motdContents.Add(ParsingNode(root));
                 if (root.TryGetProperty("extra",out var extra))
                 {
                     foreach (var obj in extra.EnumerateArray())
                     {
-                        MotdContent motdContent = new MotdContent();
-                        foreach (var item in obj.EnumerateObject())
-                        {
-                            ParsingObject(item,ref motdContent);
-                        }
-                        motdContents.Add(motdContent);
+                        motdContents.Add(ParsingNode(obj));
                     }
-                }
-                else
-                {
-                    MotdContent motdContent = new MotdContent();
-                    foreach (var item in root.EnumerateObject())
-                    {
-                        ParsingObject(item,ref motdContent);
-                    }
-                    motdContents.Add(motdContent);
                 }
             }
-            
 
             return motdContents;
         }
@@ -59,6 +45,16 @@ namespace McMotdParser.Deserializer
         public override void Write(Utf8JsonWriter writer, List<MotdContent> value, JsonSerializerOptions options)
         {
             throw new NotImplementedException();
+        }
+
+        private MotdContent ParsingNode(JsonElement element)
+        {
+            MotdContent motdContent = new MotdContent();
+            foreach (var item in element.EnumerateObject())
+            {
+                ParsingObject(item, ref motdContent);
+            }
+            return motdContent;
         }
 
         private void ParsingObject(JsonProperty property,ref MotdContent motdContent)


### PR DESCRIPTION
When using parsing from JSON the Text in den Root Element was ignored and only the Children's (Extra Elements was transformed) this fixed the behavior.

Thanks For Making such Library for .NET